### PR TITLE
Сделал явную реализацию интерфейса IEnumerator вместо IEnumerator<T>

### DIFF
--- a/System.Data.Bindings/src/collections/generic/GenericObservableList.cs
+++ b/System.Data.Bindings/src/collections/generic/GenericObservableList.cs
@@ -240,7 +240,7 @@ namespace System.Data.Bindings.Collections.Generic
 		/// <returns>
 		/// Returns enumerator object <see cref="IEnumerator"/>
 		/// </returns>
-		public IEnumerator GetEnumerator ()
+		IEnumerator IEnumerable.GetEnumerator ()
 		{
 			return (items.GetEnumerator ());
 		}
@@ -251,7 +251,7 @@ namespace System.Data.Bindings.Collections.Generic
 		/// <returns>
 		/// Returns enumerator object <see cref="IEnumerator"/>
 		/// </returns>
-		IEnumerator<T> IEnumerable<T>.GetEnumerator ()
+		public IEnumerator<T> GetEnumerator ()
 		{
 			return (items.GetEnumerator ());
 		}


### PR DESCRIPTION
Позволяет для подобных случаев
```
GenericObservableList<SomeNode> observableList = new GenericObservableList<SomeNode>();  
foreach(SomeNode node in observableList)
{
    node.Id = 0;
}
```
писать так:
```
GenericObservableList<SomeNode> observableList = new GenericObservableList<SomeNode>();  
foreach(var node in observableList)
{
    node.Id = 0;
}
```
Т.к в текущей реализации при использовании var для node, тип определаяется как object